### PR TITLE
Potential fix for code scanning alert no. 1: Incorrect conversion between integer types

### DIFF
--- a/internal/codespaces/portforwarder/port_forwarder.go
+++ b/internal/codespaces/portforwarder/port_forwarder.go
@@ -264,7 +264,11 @@ func (fwd *CodespacesPortForwarder) UpdatePortVisibility(ctx context.Context, re
 	}
 
 	// Delete the existing tunnel port to update
-	err = fwd.connection.TunnelManager.DeleteTunnelPort(ctx, fwd.connection.Tunnel, uint16(remotePort), fwd.connection.Options)
+	delPort, err := convertIntToUint16(remotePort)
+	if err != nil {
+		return fmt.Errorf("invalid remote port: %w", err)
+	}
+	err = fwd.connection.TunnelManager.DeleteTunnelPort(ctx, fwd.connection.Tunnel, delPort, fwd.connection.Options)
 	if err != nil {
 		return fmt.Errorf("error deleting tunnel port: %w", err)
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/aka76bm/cli/security/code-scanning/1](https://github.com/aka76bm/cli/security/code-scanning/1)

To fix this issue, we must check that the input port value falls into the valid range for a port (`0 < port <= 65535`) before converting from `int` to `uint16`. In `internal/codespaces/portforwarder/port_forwarder.go`, the problematic code is on line 267, where `uint16(remotePort)` is called as an argument to `DeleteTunnelPort`. To address this, introduce a bounds check before the conversion, and only proceed if the port is valid—otherwise, return an error (or fallback as appropriate for the context). The fix should also preferably use a helper function for conversion, similar to the `convertIntToUint16` function used elsewhere in the file (see lines 230-233). If `convertIntToUint16` exists, use it instead for consistency.

Specifically:
- In `UpdatePortVisibility`, add logic to convert and check `remotePort` safely before deleting the port.
- If `convertIntToUint16` exists and is suitable, reuse it; otherwise, define/import such a helper.
- Imports: If the helper uses `math` (for MaxUint16), ensure the import exists.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
